### PR TITLE
Rename snap from circleci-local-cli to circleci.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: circleci-local-cli
+name: circleci
 version: "dev"
 version-script: ./circleci.sh --version
 summary: "The CircleCI Local CLI"


### PR DESCRIPTION
To get around the manual process for submitting alias request to Snapcraft, just renaming this snap. Will worry about namespace clashes later.