### PR TITLE
Support for homebrew by creating published releases. (issue #7)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,5 +76,4 @@ jobs:
             go get github.com/tcnksm/ghr
             VERSION=$(ls *.tar.gz | sed -e 's/circleci_\([a-z0-9.-]*\)\.tar\.gz/\1/')
             echo "Pushing tarball and snap for version ${VERSION} to github releases"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} circleci_*.tar.gz
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} circleci_*.snap
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,13 @@ workflows:
   main:
     jobs:
       - build
-      - publish:
+      #- publish-snap:
+      #    requires:
+      #      - build
+      #    filters:
+      #      branches:
+      #        only: master
+      - publish-tarball:
           requires:
             - build
           filters:
@@ -18,15 +24,21 @@ jobs:
       - image: cibuilds/snapcraft:stable
     steps:
       - checkout
+      #- run:
+      #    name: "Build Snap"
+      #    command: snapcraft
       - run:
-          name: "Build Snap"
-          command: snapcraft
+          name: Generate tarball
+          command: |
+            VERSION=$(bash circleci.sh --version)
+            echo "Creating version ${VERSION}"
+            tar -czf circleci-${VERSION}.tar.gz circleci.sh
       - persist_to_workspace:
           root: .
           paths:
             - "*.snap"
 
-  publish:
+  publish-snap:
     docker:
       - image: cibuilds/snapcraft:stable
     steps:
@@ -38,3 +50,20 @@ jobs:
             mkdir .snapcraft
             echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
             snapcraft push *.snap --release stable
+
+
+
+  publish-tarball:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Publish release on github (for homebrew)
+          command: |
+            go get github.com/tcnksm/ghr
+            VERSION=$(bash circleci.sh --version)
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} v${VERSION} circleci-${VERSION}.tar.gz
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
           paths:
             - "*.snap"
             - "*.tar.gz"
+      - store_artifacts:
+          path: circleci-${VERSION}.tar.gz
+
 
   publish-snap:
     docker:
@@ -67,5 +70,3 @@ jobs:
             VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9.-]*\)\.tar\.gz/\1/')
             echo "Pushing version ${VERSION} to github releases"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} v${VERSION} circleci-${VERSION}.tar.gz
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             - "*.snap"
             - "*.tar.gz"
       - store_artifacts:
-          path: circleci-${VERSION}.tar.gz
+          path: circleci-*.tar.gz
 
 
   publish-snap:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
       - image: cibuilds/snapcraft:stable
     steps:
       - checkout
-      #- run:
-      #    name: "Build Snap"
-      #    command: snapcraft
+      - run:
+          name: "Build Snap"
+          command: snapcraft
       - run:
           name: Generate tarball
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,8 @@ jobs:
           name: Publish release on github (for homebrew)
           command: |
             go get github.com/tcnksm/ghr
-            VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9-]*\).tar.gz/\1/')
+            VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9.-]*\)\.tar\.gz/\1/')
+            echo "Pushing version ${VERSION} to github releases"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} v${VERSION} circleci-${VERSION}.tar.gz
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,17 @@ jobs:
           command: |
             VERSION=$(bash circleci.sh --version)
             echo "Creating version ${VERSION}"
-            tar -czf circleci-${VERSION}.tar.gz circleci.sh
+            mkdir artifacts
+            tar -czf artifacts/circleci-${VERSION}.tar.gz circleci.sh
       - persist_to_workspace:
           root: .
           paths:
             - "*.snap"
             - "*.tar.gz"
       - store_artifacts:
-          path: circleci-*.tar.gz
+          path: artifacts
+      - store_artifacts:
+          path: "artifacts/*.tar.gz"
 
 
   publish-snap:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
           root: .
           paths:
             - "*.snap"
+            - "*.tar.gz"
 
   publish-snap:
     docker:
@@ -63,7 +64,7 @@ jobs:
           name: Publish release on github (for homebrew)
           command: |
             go get github.com/tcnksm/ghr
-            VERSION=$(bash circleci.sh --version)
+            VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9-]*\).tar.gz/\1/')
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} v${VERSION} circleci-${VERSION}.tar.gz
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,14 @@ jobs:
           command: |
             VERSION=$(bash circleci.sh --version)
             echo "Creating version ${VERSION}"
+            tar -czf circleci-${VERSION}.tar.gz circleci.sh
+      - run:
+          name: Copy artifacts to folder
+          command: |
+            # store_artifacts doesnt seem to support expansion/interpolation
             mkdir artifacts
-            tar -czf artifacts/circleci-${VERSION}.tar.gz circleci.sh
+            cp circleci-*.tar.gz artifacts/
+            cp *.snap artifacts
       - persist_to_workspace:
           root: .
           paths:
@@ -41,8 +47,6 @@ jobs:
             - "*.tar.gz"
       - store_artifacts:
           path: artifacts
-      - store_artifacts:
-          path: "artifacts/*.tar.gz"
 
 
   publish-snap:
@@ -72,4 +76,4 @@ jobs:
             go get github.com/tcnksm/ghr
             VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9.-]*\)\.tar\.gz/\1/')
             echo "Pushing version ${VERSION} to github releases"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} v${VERSION} circleci-${VERSION}.tar.gz
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete v${VERSION} circleci-${VERSION}.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@ workflows:
   main:
     jobs:
       - build
-      #- publish-snap:
-      #    requires:
-      #      - build
-      #    filters:
-      #      branches:
-      #        only: master
-      - publish-tarball:
+      - publish-snap:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - publish-github-releases:
           requires:
             - build
           filters:
@@ -30,15 +30,15 @@ jobs:
       - run:
           name: Generate tarball
           command: |
-            VERSION=$(bash circleci.sh --version)
+            VERSION="v$(bash circleci.sh --version)"
             echo "Creating version ${VERSION}"
-            tar -czf circleci-${VERSION}.tar.gz circleci.sh
+            tar -czf circleci_${VERSION}.tar.gz circleci.sh
       - run:
           name: Copy artifacts to folder
           command: |
             # store_artifacts doesnt seem to support expansion/interpolation
             mkdir artifacts
-            cp circleci-*.tar.gz artifacts/
+            cp circleci_v*.tar.gz artifacts/
             cp *.snap artifacts
       - persist_to_workspace:
           root: .
@@ -64,7 +64,7 @@ jobs:
 
 
 
-  publish-tarball:
+  publish-github-releases:
     docker:
       - image: circleci/golang:1.8
     steps:
@@ -74,6 +74,7 @@ jobs:
           name: Publish release on github (for homebrew)
           command: |
             go get github.com/tcnksm/ghr
-            VERSION=$(ls *.tar.gz | sed -e 's/circleci-\([a-z0-9.-]*\)\.tar\.gz/\1/')
-            echo "Pushing version ${VERSION} to github releases"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete v${VERSION} circleci-${VERSION}.tar.gz
+            VERSION=$(ls *.tar.gz | sed -e 's/circleci_\([a-z0-9.-]*\)\.tar\.gz/\1/')
+            echo "Pushing tarball and snap for version ${VERSION} to github releases"
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} circleci_*.tar.gz
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} circleci_*.snap


### PR DESCRIPTION
This PR  addressed issue #7 and only modifies the config.yml to add a GitHub tarball that is versioned using version from script (matches SNAP versioning).

To be included back into CircleCI repo, a few changes are needed:

1. Uncomment the SNAP build and deploy steps which will not pass on my local repo (i can do this before merging, but will break build on my side)
2. Add `GITHUB_TOKEN` as circleci environment variable with a `public_repos` access token for circleCI repos to be able to publish release.



```
$ brew install eddiewebb/circleci/circleci
==> Tapping eddiewebb/circleci
Cloning into '/Users/eddie/homebrew/Library/Taps/eddiewebb/homebrew-circleci'...
remote: Counting objects: 7, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 7 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (7/7), done.
Tapped 1 formula (33 files, 23.9KB)
==> Installing circleci from eddiewebb/circleci
==> Downloading https://github.com/eddiewebb/local-cli/releases/download/v0.0.4705-deba4df/circleci-0.0.4705-deba4df.tar.gz
Already downloaded: /Users/n0158588/Library/Caches/Homebrew/circleci-0.0.4705.tar.gz
🍺  /usr/local/Cellar/circleci/0.0.4705: 3 files, 5.0KB, built in 1 second
$ circleci --version
0.0.4705-deba4df

```