### PR TITLE
Remove -i since docker run is not interactive

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -134,7 +134,7 @@ if is_update_available; then
   echo "INFO: There's a newer version of the CircleCI build agent available. Run 'circleci update' to update."
 fi
 
-docker run -it --rm \
+docker run -t --rm \
        -e DOCKER_API_VERSION=${DOCKER_API_VERSION:-1.23} \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v $(pwd):$(pwd) \


### PR DESCRIPTION
When using the `-i` argument, `circleci.sh` fails when called from a script:

```
Begin circleci config validation
the input device is not a TTY
```

This is making my pre-commit hook fail. Also it appears that there is no interactive mode for the tool, so it is unnecessary.