### PR TITLE
Handle spaces in directory names

### DIFF
--- a/circleci.sh
+++ b/circleci.sh
@@ -137,8 +137,8 @@ fi
 docker run -it --rm \
        -e DOCKER_API_VERSION=${DOCKER_API_VERSION:-1.23} \
        -v /var/run/docker.sock:/var/run/docker.sock \
-       -v $(pwd):$(pwd) \
+       -v "$(pwd)":"$(pwd)" \
        -v ~/.circleci/:/root/.circleci \
-       --workdir $(pwd) \
+       --workdir "$(pwd)" \
        $picard_image \
        circleci "$@"


### PR DESCRIPTION
Fixes issue brough up here: https://discuss.circleci.com/t/circleci-cli-doesnt-work-in-folders-names-with-spaces/14803/9

Patch was sent into Zendesk support by @rmccue