### PR TITLE
Disable publish jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,18 @@ workflows:
   main:
     jobs:
       - build
-      - publish-snap:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-      - publish-github-releases:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
+      #- publish-snap:
+      #    requires:
+      #      - build
+      #    filters:
+      #      branches:
+      #        only: master
+      #- publish-github-releases:
+      #    requires:
+      #      - build
+      #    filters:
+      #      branches:
+      #        only: master
 
 
 version: 2


### PR DESCRIPTION
This repo has been supplanted by another repo for maintaining the legacy CLI scripts, so want to make sure we don't accidentally publish releases from here.